### PR TITLE
Only auto-reload contents if on first page

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -1,3 +1,5 @@
+var datatable;
+
 $(document).ready(function() {
     bootstrap();
 
@@ -49,7 +51,7 @@ function recountAll() {
             if (countNew !== countOld) {
                 var difference = countNew - countOld;
 
-                if (currentPage === file) {
+                if (currentPage === file && datatable.page.info().page === 0) {
                     reloadContent();
                 }
 
@@ -106,7 +108,7 @@ function bootstrap() {
     var dataTablesLang = $('body').attr('data-language');
     var currentPage = $('.log-container h4').attr('data-file');
 
-    $('.datatable').DataTable({
+    datatable = $('.datatable').DataTable({
         ajax: baseUrl + 'ajax.php?viewlog&file=' + currentPage,
         ordering: false,
         serverSide: true,


### PR DESCRIPTION
See https://github.com/ToX82/logHappens/issues/3#issuecomment-622490349

Without this it keeps resetting to the first page if the file updates, causing it to be very hard to view the files history if it updates often.