### PR TITLE
Highlight the search term in the datatable

### DIFF
--- a/views/layouts/default.php
+++ b/views/layouts/default.php
@@ -56,6 +56,7 @@
     <script src="https://cdn.jsdelivr.net/npm/datatables.net-bs4@1/js/dataTables.bootstrap4.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/push.js@1/bin/push.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/iconify-select-plugin@1/iconify-select-plugin.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mark.js@8/dist/jquery.mark.min.js"></script>
     <script type="text/javascript" src="<?= buildAssetUrl("webroot/js/custom.js") ?>"></script>
 </body>
 </html>

--- a/webroot/js/custom.js
+++ b/webroot/js/custom.js
@@ -329,4 +329,10 @@ function bootstrap() {
             url: `https://cdn.datatables.net/plug-ins/1.10.20/i18n/${dataTablesLang}.json`,
         },
     });
+
+    // Highlight the search term in the datatable
+    datatable.on('draw', function () {
+        const body = $(datatable.table().body());
+        body.mark(datatable.search());
+    });
 }


### PR DESCRIPTION
One small feature I missed is that when I search for something, the search term is highlighted in the results.
This can be solved relatively easily with [mark.js](https://markjs.io/).

![image](https://github.com/user-attachments/assets/db208cce-5950-4c2b-8bfc-9cde8040a4e6)
