### PR TITLE
truncate button can be switched on and off 

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -6,7 +6,8 @@
             "title": "apache",
             "file": "/var/log/apache2/error.log",
             "parser": "apache24",
-            "disabled": false
+            "disabled": false,
+            "truncatable": true
         }
     }
 }

--- a/logics/Configurations.php
+++ b/logics/Configurations.php
@@ -40,6 +40,7 @@ class Configurations
             $config['file'] = $_POST["input-file"];
             $config['parser'] = $_POST["input-parser"];
             $config['disabled'] = isset($_POST['input-disabled']) ? false : true;
+            $config['truncatable'] = isset($_POST['input-truncatable']) ? true : false;
 
             $configurations->$configName = $config;
 

--- a/logics/Parsers.php
+++ b/logics/Parsers.php
@@ -115,6 +115,7 @@ class Parsers
             'icon' => $data['icon'],
             'color' => $data['color'],
             'writable' => is_writable($data['file']),
+            'truncatable' => $data['truncatable'] ?? true,
             'title' => $data['title'],
         ];
     }

--- a/views/configurations/add.php
+++ b/views/configurations/add.php
@@ -60,6 +60,14 @@
                             </select>
                             <div class="form-text">Select the parser that matches your log format</div>
                         </div>
+
+                        <div class="mb-4">
+                            <div class="form-check form-switch">
+                                <label class="form-check-label me-2" for="input-truncatable">Should it be allowed to truncate the log file?</label>
+                                <input type="checkbox" class="form-check-input" id="input-truncatable" name="input-truncatable"
+                                    role="switch" checked>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Colonna destra -->

--- a/views/configurations/edit.php
+++ b/views/configurations/edit.php
@@ -102,10 +102,16 @@
                     </div>
                 </div>
 
-                <div class="form-check form-switch">
+                <div class="form-check form-switch mb-4">
                     <label class="form-check-label me-2" for="input-disabled">Show this configuration in the sidebar</label>
                     <input type="checkbox" class="form-check-input" id="input-disabled" name="input-disabled"
                         role="switch" <?= $config->disabled === true ? '' : 'checked'; ?>>
+                </div>
+
+                <div class="form-check form-switch mb-4">
+                    <label class="form-check-label me-2" for="input-truncatable">Should it be allowed to truncate the log file?</label>
+                    <input type="checkbox" class="form-check-input" id="input-truncatable" name="input-truncatable"
+                        role="switch" <?= ($config->truncatable ?? true) === true ? 'checked' : ''; ?>>
                 </div>
 
                 <div class="d-flex justify-content-end gap-2">

--- a/views/parsers/log_reader.php
+++ b/views/parsers/log_reader.php
@@ -4,16 +4,18 @@
     </i>
     <span class="log-title"><?= $logs['title'] ?></span>
 
-    <?php if ($logs['writable'] === true) { ?>
-        <a class="btn-openModal ml-4" href="<?= buildUrl("truncate/" . $logs['file']) ?>">
-            <span class="iconify" data-icon="ion:trash-bin" data-inline="false" style="color: red;" data-width="30"></span>
-        </a>
-    <?php } else { ?>
-        <a class="ml-4" href="<?= buildUrl("display/troubleshooting") ?>">
-            <small>
-                You don't have write permissions on this file. Why?
-            </small>
-        </a>
+    <?php if ($logs['truncatable'] === true) { ?>
+        <?php if ($logs['writable'] === true) { ?>
+            <a class="btn-openModal ml-4" href="<?= buildUrl("truncate/" . $logs['file']) ?>">
+                <span class="iconify" data-icon="ion:trash-bin" data-inline="false" style="color: red;" data-width="30"></span>
+            </a>
+        <?php } else { ?>
+            <a class="ml-4" href="<?= buildUrl("display/troubleshooting") ?>">
+                <small>
+                    You don't have write permissions on this file. Why?
+                </small>
+            </a>
+        <?php } ?>
     <?php } ?>
 </h4>
 


### PR DESCRIPTION
In my use case, I have some logs that should not be deleted. 
Therefore, I have included an option to configure the visibility of the truncate button for each parser. 
When configuring the parse, you can now select whether the button is displayed or not:
![image](https://github.com/user-attachments/assets/e8c2d3bc-d21a-40ca-883a-0dbcfd9fa790)
